### PR TITLE
fixed seekSet bug when SD Card is glitch

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -768,7 +768,7 @@ inline void get_sdcard_commands()
             }
 
             SERIAL_ECHO("SD Card error: ");
-            SERIAL_ECHOLN((unsigned int)card.errorCode());
+            SERIAL_ECHOLN((int)card.errorCode());
 
             //On an error, reset the error, reset the file position and try again.
             card.clearError();
@@ -785,7 +785,7 @@ inline void get_sdcard_commands()
             while (retryCnt --) {
                 if(card.setIndex(endOfLineFilePosition)) {
                     SERIAL_ECHO("Restart reading last command from position: ");
-                    SERIAL_ECHOLN((int)endOfLineFilePosition);
+                    SERIAL_ECHOLN((unsigned int)endOfLineFilePosition);
                     return; // seek done, try to restart command reading without stopping the entire process.
                 }
             }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -768,7 +768,7 @@ inline void get_sdcard_commands()
             }
 
             SERIAL_ECHO("SD Card error: ");
-            SERIAL_ECHOLN((int)card.errorCode());
+            SERIAL_ECHOLN((unsigned int)card.errorCode());
 
             //On an error, reset the error, reset the file position and try again.
             card.clearError();

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -65,7 +65,7 @@ public:
   FORCE_INLINE bool eof() { return sdpos>=filesize ;}
   FORCE_INLINE int16_t get() {  sdpos = file.curPosition();return (int16_t)file.read();}
   FORCE_INLINE int16_t fgets(char* str, int16_t num) { return file.fgets(str, num, NULL); }
-  FORCE_INLINE void setIndex(long index) {sdpos = index;file.seekSet(index);}
+  FORCE_INLINE bool setIndex(long index) { bool seekResult = file.seekSet(index); if (seekResult){ sdpos = index; }; return seekResult; }
   FORCE_INLINE uint8_t percentDone(){if(!isFileOpen()) return 0; if(filesize) return sdpos/((filesize+99)/100); else return 0;}
   FORCE_INLINE char* getWorkDirName(){workDir.getFilename(filename);return filename;}
   FORCE_INLINE bool atRoot() { return workDirDepth==0; }

--- a/Marlin/machinesettings.h
+++ b/Marlin/machinesettings.h
@@ -21,7 +21,8 @@ class MachineSettings {
     // recall settings
     bool recall(uint8_t index);
 
-	bool has_saved_settings(uint8_t index) const { return (index < MAX_MACHINE_SETTINGS) ? settings[index] : false; }
+    //FIXME this function not used and cause compilation error
+	// bool has_saved_settings(uint8_t index) const { return (index < MAX_MACHINE_SETTINGS) ? settings[index] : false; }
 
   private:
     // the structure of each setting


### PR DESCRIPTION
The error happens when SD Card is not in perfect condition and when fatGet call returns error inside SdBaseFile::seekSet. As a result "CardReader::sdpos" is not equal to "SdBaseFile::curPosition_" and a part of gcode will be missed in next block reading from SD Card. Sequence of commands execution will be violated.
This is bugfix for issue #112.
Not completely tested yet.

